### PR TITLE
Fix LearnMore Page

### DIFF
--- a/WebUI/src/views/LearnMore.vue
+++ b/WebUI/src/views/LearnMore.vue
@@ -51,7 +51,7 @@
                             </p>
                         </div>
                         <a href="https://github.com/lllyasviel/Fooocus" 
-                            class="flex gap-1 items-center "><span class="">Leam more</span><span
+                            class="flex gap-1 items-center "><span class="">Learn more</span><span
                                 class="svg-icon i-arrow-right w-4 h-4"></span></a>
                     </div>
                 </div>
@@ -67,7 +67,7 @@
                             </p>
                         </div>
                         <a href="https://github.com/comfyanonymous/ComfyUI" 
-                            class="flex gap-1 items-center "><span class="">Leam more</span><span
+                            class="flex gap-1 items-center "><span class="">Learn more</span><span
                                 class="svg-icon i-arrow-right w-4 h-4"></span></a>
                     </div>
                 </div>
@@ -81,7 +81,7 @@
                             </p>
                         </div>
                         <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui" 
-                            class="flex gap-1 items-center "><span class="">Leam more</span><span
+                            class="flex gap-1 items-center "><span class="">Learn more</span><span
                                 class="svg-icon i-arrow-right w-4 h-4"></span></a>
                     </div>
                 </div>
@@ -95,7 +95,7 @@
                             </p>
                         </div>
                         <a href="https://github.com/vladmandic/automatic" 
-                            class="flex gap-1 items-center "><span class="">Leam more</span><span
+                            class="flex gap-1 items-center "><span class="">Learn more</span><span
                                 class="svg-icon i-arrow-right w-4 h-4"></span></a>
                     </div>
                 </div>
@@ -110,7 +110,7 @@
                 determined near launch}</p>
             <div class="pt-3 flex justify-center">
                 <a href="https://github.com/intel/ai-playground" 
-                    class="flex gap-1 items-center"><span class="">Leam more</span><span
+                    class="flex gap-1 items-center"><span class="">Learn more</span><span
                         class="svg-icon i-arrow-right w-4 h-4"></span></a>
             </div>
         </div>


### PR DESCRIPTION
* Fix spelling of Learn More

**Description:**

Please provide a brief description of the changes made in this pull request.

The `WebUI/src/views/LearnMore.vue`  said "Leam More", fixing the spelling of Learn

**Related Issue:**

If this pull request is related to any existing issue, please mention the issue number here.

No referenced issue AFAIK

**Changes Made:**

Please list down the specific changes made in this pull request.

Trivial replacement of Leam for Learn (`sed -i 's/Leam/Learn/g' WebUI/src/views/LearnMore.vue`)

**Testing Done:**

Please describe the testing that has been done to ensure the changes made in this pull request are functioning as expected.

No test done

**Screenshots:**

If applicable, please provide screenshots or GIFs or videos to visually demonstrate the changes made.

These are the strings I am trying to change:

![image](https://github.com/user-attachments/assets/60135867-d46a-4968-aea9-026cf73f9d7b)


**Checklist:**

- [ ] I have tested the changes locally.
- [X] I have self-reviewed the code changes.
- [X] I have updated the documentation, if necessary.
