### PR TITLE
[MTL] Downgrade IPEX to 2.1.40+xpu for MTL

### DIFF
--- a/service/requirements-ultra.txt
+++ b/service/requirements-ultra.txt
@@ -25,8 +25,8 @@ unstructured==0.14.6
 setuptools==69.5.1
 
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/mtl/us/
-torch==2.3.1+cxx11.abi
-torchvision==0.18.1+cxx11.abi
-torchaudio==2.3.1+cxx11.abi
-intel-extension-for-pytorch==2.3.110+xpu
+torch==2.1.0.post3
+torchvision==0.16.0.post3
+torchaudio==2.1.0.post3
+intel-extension-for-pytorch==2.1.40+xpu
 mkl-dpcpp==2024.2.1


### PR DESCRIPTION
**Description:**

IPEX 2.3.110+xpu for MTL doesn't work with python 3.11, downgrade to IPEX 2.1.40+xpu for MTL.

**Related Issue:**

https://github.com/intel/intel-extension-for-pytorch/issues/710

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
