### PR TITLE
[ACM] Downgrade IPEX to 2.1.40+xpu for ACM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,10 +58,10 @@ conda install libuv -y
 cd service
 
 @REM for Desktop-dGPU (e.g. A770)
-pip install -r requriements-arc.txt
+pip install -r requirements-arc.txt
 
 @REM for Intel Core Ultra-H (MTL)
-pip install -r requriements-ultra.txt
+pip install -r requirements-ultra.txt
 ```
 
 2. Check whether the XPU environment is correct

--- a/service/requirements-arc.txt
+++ b/service/requirements-arc.txt
@@ -26,8 +26,8 @@ setuptools==69.5.1
 
 
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-torch==2.3.1+cxx11.abi
-torchvision==0.18.1+cxx11.abi
-torchaudio==2.3.1+cxx11.abi
-intel-extension-for-pytorch==2.3.110+xpu
+torch==2.1.0.post3
+torchvision==0.16.0.post3
+torchaudio==2.1.0.post3
+intel-extension-for-pytorch==2.1.40+xpu
 mkl-dpcpp==2024.2.1


### PR DESCRIPTION
**Description:**

IPEX 2.3.110+xpu for ACM doesn't work with python 3.11, downgrade to IPEX 2.1.40+xpu for ACM.

**Related Issue:**

https://github.com/intel/AI-Playground/issues/80

**Changes Made:**

Downgrade IPEX to 2.1.40+xpu for ACM

**Testing Done:**

Functioning as expected, tested with Arc 770 (8 GB).

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.
