### PR TITLE
Restart last inference backend

### DIFF
--- a/WebUI/electron/subprocesses/apiService.ts
+++ b/WebUI/electron/subprocesses/apiService.ts
@@ -40,7 +40,7 @@ export interface ApiService {
 }
 
 export abstract class LongLivedPythonApiService implements ApiService {
-    readonly name: Service
+    readonly name: BackendServiceName
     readonly baseUrl: string
     readonly port: number
     readonly win: BrowserWindow
@@ -63,7 +63,7 @@ export abstract class LongLivedPythonApiService implements ApiService {
 
     readonly appLogger = appLoggerInstance
 
-    constructor(name: Service, port: number, win: BrowserWindow, settings: LocalSettings) {
+    constructor(name: BackendServiceName, port: number, win: BrowserWindow, settings: LocalSettings) {
         this.win = win
         this.name = name
         this.port = port

--- a/WebUI/src/components/InstallationManagement.vue
+++ b/WebUI/src/components/InstallationManagement.vue
@@ -141,7 +141,7 @@ function isSomethingLoading(): boolean {
   return components.value.some((item) => item.isLoading)
 }
 
-async function installBackend(name: Service) {
+async function installBackend(name: BackendServiceName) {
   somethingChanged.value = true;
   loadingComponents.value.add(name)
   const setupProgress = await backendServices.setUpService(name)
@@ -153,7 +153,7 @@ async function installBackend(name: Service) {
   }
 }
 
-async function repairBackend(name: Service) {
+async function repairBackend(name: BackendServiceName) {
   loadingComponents.value.add(name)
   const stopStatus = await backendServices.stopService(name)
   if (stopStatus !== 'stopped') {
@@ -163,7 +163,7 @@ async function repairBackend(name: Service) {
   await installBackend(name);
 }
 
-async function restartBackend(name: Service) {
+async function restartBackend(name: BackendServiceName) {
   loadingComponents.value.add(name)
   const stopStatus = await backendServices.stopService(name)
   if (stopStatus !== 'stopped') {

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -68,7 +68,7 @@ type electronAPI = {
     onServiceInfoUpdate(callback: (service: ApiServiceInformation) => void): void,
 };
 
-type SetupProgress = {serviceName: Service, step: string, status: "executing"|"failed"|"success", debugMessage: string}
+type SetupProgress = {serviceName: BackendServiceName, step: string, status: "executing"|"failed"|"success", debugMessage: string}
 
 type Chrome = {
     webview: WebView;
@@ -313,6 +313,6 @@ type CheckModelAlreadyLoadedResult = {
 
 type SDGenerateState = "no_start" | "input_image" | "load_model" | "load_model_components" | "generating" | "image_out" | "error"
 
-type Service = "ai-backend" | "comfyui-backend" | "llamacpp-backend"
+type BackendServiceName = "ai-backend" | "comfyui-backend" | "llamacpp-backend"
 
-type ApiServiceInformation = { serviceName: Service, status: BackendStatus , baseUrl: string, port: number, isSetUp: boolean, isRequired: boolean }
+type ApiServiceInformation = { serviceName: BackendServiceName, status: BackendStatus , baseUrl: string, port: number, isSetUp: boolean, isRequired: boolean }

--- a/WebUI/src/views/Answer.vue
+++ b/WebUI/src/views/Answer.vue
@@ -461,6 +461,10 @@ async function generate(chatContext: ChatItem[]) {
   if (processing.value || chatContext.length == 0) { return; }
 
   try {
+    const inferenceBackendService: BackendServiceName = textInference.backend === 'IPEX-LLM' ? "ai-backend" : "llamacpp-backend"
+    await globalSetup.resetLastUsedInferenceBackend(inferenceBackendService)
+    globalSetup.updateLastUsedBackend(inferenceBackendService)
+
     textIn.value = util.escape2Html(chatContext[chatContext.length - 1].question);
     textOut.value = "";
     receiveOut = "";
@@ -478,7 +482,6 @@ async function generate(chatContext: ChatItem[]) {
       enable_rag: ragData.enable,
       model_repo_id: textInference.backend === 'IPEX-LLM' ? globalSetup.modelSettings.llm_model : globalSetup.modelSettings.ggufLLM_model,
     };
-    comfyUi.free();
     const response = await fetch(`${currentBackendAPI.value}/api/llm/chat`, {
       method: "POST", headers: {
         "Content-Type": "application/json"

--- a/WebUI/src/views/Create.vue
+++ b/WebUI/src/views/Create.vue
@@ -84,10 +84,12 @@ import LoadingBar from "../components/LoadingBar.vue";
 import PaintInfo from '@/components/PaintInfo.vue';
 import { useImageGeneration } from '@/assets/js/store/imageGeneration';
 import { useStableDiffusion } from '@/assets/js/store/stableDiffusion';
+import {useGlobalSetup} from "@/assets/js/store/globalSetup.ts";
 
 
 const imageGeneration = useImageGeneration();
 const stableDiffusion = useStableDiffusion();
+const globalSetup = useGlobalSetup();
 const i18nState = useI18N().state;
 const downloadModel = reactive({
     downloading: false,
@@ -105,6 +107,10 @@ const emits = defineEmits<{
 async function generateImage() {
   await ensureModelsAreAvailable();
   reset();
+  const inferenceBackendService: BackendServiceName = imageGeneration.backend === 'comfyui' ? "comfyui-backend" : "ai-backend"
+  await globalSetup.resetLastUsedInferenceBackend(inferenceBackendService)
+  globalSetup.updateLastUsedBackend(inferenceBackendService)
+
   await imageGeneration.generate();
 }
 

--- a/WebUI/src/views/Enhance.vue
+++ b/WebUI/src/views/Enhance.vue
@@ -398,7 +398,12 @@ async function generate() {
     }
     if (processing.value) { return; }
     await checkModel();
-    try {
+    const inferenceBackendService: BackendServiceName =  "ai-backend"
+    await globalSetup.resetLastUsedInferenceBackend(inferenceBackendService)
+    globalSetup.updateLastUsedBackend(inferenceBackendService)
+
+
+  try {
         processing.value = true;
         const extParams = getParams();
         const model_repo_id =


### PR DESCRIPTION
**Description:**

We now have multiple inference backends using the same inference memory. To prevent out of memory issues, we should restart the last used inference backend to release all held claims.

**Changes Made:**

* restart previously used inference backends when using a different backend to prevent oom issues

**Testing Done:**

Tested locally on BMG.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
