### PR TITLE
fix: answer tab generating text will stay in its chat window when swi…

### DIFF
--- a/WebUI/src/assets/js/store/conversations.ts
+++ b/WebUI/src/assets/js/store/conversations.ts
@@ -5,10 +5,10 @@ export const useConversations = defineStore("conversations", () => {
     const activeKey = ref('');
     const activeConversation = computed(() => conversationList.value[activeKey.value]);
 
-    const addToActiveConversation = (item: ChatItem) => {
-        const list = conversationList.value[activeKey.value];
+    const addToActiveConversation = (key: string, item: ChatItem) => {
+        const list = conversationList.value[key];
         list.push(item);
-        addNewConversationIfLatestIsNotEmpty(conversationList.value);
+        addNewConversationIfLatestIsNotEmpty(conversationList.value, activeKey.value);
     }
 
     function deleteConversation(conversationKey: string) {
@@ -49,8 +49,22 @@ export const useConversations = defineStore("conversations", () => {
     }
 });
 
-function addNewConversationIfLatestIsNotEmpty(list: Record<string, ChatItem[]>) {
-    if (Object.values(list).at(-1)?.length !== 0) {
-        list[new Date().getTime().toString()] = [];
+function addNewConversationIfLatestIsNotEmpty(
+    list: Record<string, ChatItem[]>,
+    conversationKey?: string
+  ) {
+    if (conversationKey && list[conversationKey].length !== 0) {
+      // If the last conversation is already empty, do nothing
+      const lastKey = Object.keys(list).at(-1);
+      if (lastKey && list[lastKey].length === 0) return;
+  
+      // Otherwise, create a fresh conversation
+      list[new Date().getTime().toString()] = [];
+      return;
     }
-}
+  
+    // Fallback old logic
+    if (Object.values(list).at(-1)?.length !== 0) {
+      list[new Date().getTime().toString()] = [];
+    }
+  }


### PR DESCRIPTION
…tching chat and display a loading icon

**Description:**

- Addresses the functionality of switching chats and displaying a loading icon while ensuring a seamless user experience when interacting with multiple chat windows.

**Related Issue:**

 - Resolves issues with inconsistent chat behavior across multiple windows and the absence of a clear loading indicator during chat generation.

**Changes Made:**

- Implemented logic to maintain chat state consistency across multiple windows when generating or regenerating a chat.
- Added a loading icon to visually indicate chat generation or regeneration processes.

**Testing Done:**

- Generating a chat in a different window and moving a different window and checking if the other chat will stay in another window.
- Regenerating a chat in a different window and moving a different window and checking if the other chat will stay in another window.
- Generating and regenerating check on loading icon in tab.

**Screenshots:**

- Showing current issue
https://github.com/user-attachments/assets/cde4156e-1653-44b9-9796-033e49b8de5a

- After Fixes
https://github.com/user-attachments/assets/fcaaa840-a42d-46f8-92c9-2e9939623c01

**Checklist:**

- [X] I have tested the changes locally.
- [X] I have self-reviewed the code changes.
- [X] I have updated the documentation, if necessary.
