### PR TITLE
Make device detection more type safe and resilient

### DIFF
--- a/WebUI/electron/subprocesses/deviceArch.ts
+++ b/WebUI/electron/subprocesses/deviceArch.ts
@@ -1,5 +1,5 @@
 // https://github.com/intel/compute-runtime/blob/master/shared/source/dll/devices/devices_base.inl
-const ID2ARCH: { [key: number]: string } = {
+const ID2ARCH: { [key: number]: Arch } = {
     // bmg
     0xE202: "bmg",
     0xE20B: "bmg",
@@ -64,11 +64,11 @@ const ID2ARCH: { [key: number]: string } = {
     // 0x7D41: "arl",
 };
 
-export function getDeviceArch(deviceId: number): string {
+export function getDeviceArch(deviceId: number): Arch {
     return ID2ARCH[deviceId] || "unknown";
 }
 
-export function getArchPriority(arch: string): number {
+export function getArchPriority(arch: Arch): number {
     switch (arch) {
         case "bmg": return 4;
         case "acm": return 3;
@@ -77,3 +77,5 @@ export function getArchPriority(arch: string): number {
         default: return 0;
     }
 }
+
+export type Arch = "bmg" | "acm" | "lnl" | "mtl" | "unknown"


### PR DESCRIPTION
**Description:**

This PR makes the device check a bit more type safe and resilient to help during local development

**Changes Made:**

* improve typing of device check
* return unknown instead of failing if no device is detected

**Testing Done:**

Tested locally 

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
