### PR TITLE
Re-enable safety check option

### DIFF
--- a/WebUI/src/assets/js/store/imageGeneration.ts
+++ b/WebUI/src/assets/js/store/imageGeneration.ts
@@ -311,7 +311,6 @@ export const useImageGeneration = defineStore(
           'negativePrompt',
           'batchSize',
           'imagePreview',
-          'safetyCheck',
         ],
       },
       {
@@ -338,7 +337,6 @@ export const useImageGeneration = defineStore(
           'negativePrompt',
           'batchSize',
           'imagePreview',
-          'safetyCheck',
         ],
       },
       {
@@ -364,7 +362,6 @@ export const useImageGeneration = defineStore(
           'inferenceSteps',
           'batchSize',
           'imagePreview',
-          'safetyCheck',
         ],
       },
       {

--- a/WebUI/src/assets/js/store/imageGeneration.ts
+++ b/WebUI/src/assets/js/store/imageGeneration.ts
@@ -356,13 +356,7 @@ export const useImageGeneration = defineStore(
           lora: 'latent-consistency/lcm-lora-sdxl',
         },
         displayedSettings: ['imageModel', 'inpaintModel', 'guidanceScale', 'scheduler'],
-        modifiableSettings: [
-          'resolution',
-          'seed',
-          'inferenceSteps',
-          'batchSize',
-          'imagePreview',
-        ],
+        modifiableSettings: ['resolution', 'seed', 'inferenceSteps', 'batchSize', 'imagePreview'],
       },
       {
         name: 'Manual',
@@ -682,6 +676,7 @@ export const useImageGeneration = defineStore(
               return -1
           }
         }
+
         return {
           type: modelTypeToId(requiredModel.type),
           repo_id: requiredModel.model,
@@ -689,6 +684,7 @@ export const useImageGeneration = defineStore(
           additionalLicenseLink: requiredModel.additionalLicenceLink,
         }
       }
+
       const checkList: CheckModelAlreadyLoadedParameters[] =
         workflow.comfyUIRequirements.requiredModels.map(extractDownloadModelParamsFromString)
       const checkedModels: CheckModelAlreadyLoadedResult[] =

--- a/WebUI/src/components/SettingsImageGeneration.vue
+++ b/WebUI/src/components/SettingsImageGeneration.vue
@@ -62,6 +62,14 @@
           v-model="imageGeneration.negativePrompt"
         ></textarea>
       </div>
+      <div v-if="modifiableOrDisplayed('safetyCheck')" class="flex items-center gap-5">
+        <p>{{ languages.SETTINGS_MODEL_SAFE_CHECK }}</p>
+        <button
+          class="v-checkbox-control flex-none w-5 h-5"
+          :class="{ 'v-checkbox-checked': imageGeneration.safeCheck }"
+          @click="() => (imageGeneration.safeCheck = !imageGeneration.safeCheck)"
+        ></button>
+      </div>
       <h2
         v-if="
           anyModifiableOrDisplayed([


### PR DESCRIPTION
**Description:**

This PR re-enables the safety check option for the Default Mode - Standard workflows.

**Changes Made:**

* re-enable safety check checkbox for SD1.5 workflows

**Testing Done:**

Tested locally

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
