### PR TITLE
Prevent unnecessary network calls so that AI-Playground works when offline

### DIFF
--- a/service/comfyui_downloader.py
+++ b/service/comfyui_downloader.py
@@ -121,6 +121,14 @@ def _install_pip_requirements(requirements_txt_path: str):
 
 
 def install_pypi_package(packageSpecifier: str):
+    installed_packages = aipg_utils.call_subprocess(f"{service_config.comfyui_python_exe} -m pip list")
+    if packageSpecifier.endswith(".whl"):
+        package_name = packageSpecifier.split("/")[-1].split("-")[0]
+    else:
+        package_name = packageSpecifier.split("==")[0]
+    if package_name in installed_packages:
+        logging.info(f"package {package_name} already installed. Omitting installation")
+        return
     if packageSpecifier.endswith(".whl"):
         pip_specifier = os.path.abspath(os.path.join(service_config.comfyui_python_env, packageSpecifier.split("/")[-1]))
         try:


### PR DESCRIPTION
**Description:**

This PR prevents unnecessary network calls during ComfyUI workflow dependency checks so that AI-Playground works when offline.

**Changes Made:**

* ComfyUI workflow python dependency installer now checks if dependencies are installed before making network calls.

**Testing Done:**

Tested locally

**Screenshots:**

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/840c6ad6-d66e-479a-9486-b678ce299111" />

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
