### PR TITLE
Font size buttons removed from settings and back in Answer tab

### DIFF
--- a/WebUI/src/components/SettingsBasic.vue
+++ b/WebUI/src/components/SettingsBasic.vue
@@ -105,28 +105,6 @@
           ></button>
         </div>
       </div>
-      <div class="flex items-center gap-3">
-        <p>Adjust Font Size</p>
-        <button
-          class="flex items-center justify-center gap-2 border border-white rounded-md text-sm px-4 py-1"
-          @click="textInference.increaseFontSize"
-          :disabled="textInference.isMaxSize"
-          :class="{ 'opacity-50 cursor-not-allowed': textInference.isMaxSize }"
-        >
-          <span class="svg-icon i-zoom-in w-4 h-4"></span>
-          <span>{{ languages.INCREASE_FONT_SIZE }}</span>
-        </button>
-
-        <button
-          class="flex items-center justify-center gap-2 border border-white rounded-md text-sm px-4 py-1"
-          @click="textInference.decreaseFontSize"
-          :disabled="textInference.isMinSize"
-          :class="{ 'opacity-50 cursor-not-allowed': textInference.isMinSize }"
-        >
-          <span class="svg-icon i-zoom-out w-4 h-4"></span>
-          <span>{{ languages.DECREASE_FONT_SIZE }}</span>
-        </button>
-      </div>
       <div class="flex flex-col gap-2">
         <p>Max Tokens</p>
         <slide-bar

--- a/WebUI/src/views/Answer.vue
+++ b/WebUI/src/views/Answer.vue
@@ -295,6 +295,24 @@
                 <span class="svg-icon i-clear w-4 h-4"></span>
                 <span>{{ languages.ANSWER_ERROR_CLEAR_SESSION }}</span>
             </button> -->
+            <button
+              class="flex items-center flex-none justify-center gap-2 border border-white rounded-md text-sm px-4 py-1 ml-2"
+              @click="textInference.increaseFontSize"
+              :disabled="textInference.isMaxSize"
+              :class="{ 'opacity-50 cursor-not-allowed': textInference.isMaxSize }"
+            >
+              <span class="svg-icon i-zoom-in w-4 h-4"></span>
+              <span>{{ languages.INCREASE_FONT_SIZE }}</span>
+            </button>
+            <button
+              class="flex items-center flex-none justify-center gap-2 border border-white rounded-md text-sm px-4 py-1 ml-2"
+              @click="textInference.decreaseFontSize"
+              :disabled="textInference.isMinSize"
+              :class="{ 'opacity-50 cursor-not-allowed': textInference.isMinSize }"
+            >
+              <span class="svg-icon i-zoom-out w-4 h-4"></span>
+              <span>{{ languages.DECREASE_FONT_SIZE }}</span>
+            </button>
           </div>
           <div
             v-show="textInference.backend !== 'LLAMA.CPP'"


### PR DESCRIPTION
**Description:**

Font size buttons removed from settings and back in Answer tab

**Checklist:**

- [X] I have tested the changes locally.
- [X] I have self-reviewed the code changes.
