### PR TITLE
Change git portable from minimal to standard version

### DIFF
--- a/WebUI/build/installer.nsh
+++ b/WebUI/build/installer.nsh
@@ -21,7 +21,6 @@
         DetailPrint "Extracting python environment..."
         nsExec::ExecToLog '"$INSTDIR\resources\7zr.exe" x "$INSTDIR\resources\prototype-python-env.7z" -o"$INSTDIR\resources"'
         Delete "$INSTDIR\resources\prototype-python-env.7z"
-        Delete "$INSTDIR\resources\7zr.exe"
 
     StrCpy $0 "$INSTDIR"
     StrCpy $1 "_model_backup"

--- a/WebUI/electron/subprocesses/aiBackendService.ts
+++ b/WebUI/electron/subprocesses/aiBackendService.ts
@@ -2,7 +2,7 @@ import * as filesystem from 'fs-extra'
 import { ChildProcess, spawn } from 'node:child_process'
 import path from 'node:path'
 import { existingFileOrError } from './osProcessHelper.ts'
-import { aiBackendServiceDir, LongLivedPythonApiService, LsLevelZeroService } from './service.ts'
+import { aiBackendServiceDir, GitService, LongLivedPythonApiService, LsLevelZeroService } from './service.ts'
 
 export class AiBackendService extends LongLivedPythonApiService {
   readonly pythonEnvDir = path.resolve(path.join(this.baseDir, `${this.name}-env`))
@@ -11,6 +11,7 @@ export class AiBackendService extends LongLivedPythonApiService {
   readonly uvPip = this.lsLevelZero.uvPip
   readonly pip = this.uvPip.pip
   readonly python = this.pip.python
+  readonly git = new GitService()
 
   readonly isRequired = true
   readonly serviceDir = aiBackendServiceDir()
@@ -89,6 +90,7 @@ export class AiBackendService extends LongLivedPythonApiService {
     didProcessExitEarlyTracker: Promise<boolean>
   }> {
     const additionalEnvVariables = {
+      PATH: `${process.env.PATH};${path.join(this.git.dir, 'cmd')}`,
       SYCL_ENABLE_DEFAULT_CONTEXTS: '1',
       SYCL_CACHE_PERSISTENT: '1',
       PYTHONIOENCODING: 'utf-8',

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -204,6 +204,7 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
     didProcessExitEarlyTracker: Promise<boolean>
   }> {
     const additionalEnvVariables = {
+      PATH: `${process.env.PATH};${path.join(this.git.dir, 'cmd')}`,
       SYCL_ENABLE_DEFAULT_CONTEXTS: '1',
       SYCL_CACHE_PERSISTENT: '1',
       PYTHONIOENCODING: 'utf-8',

--- a/service/comfyui_downloader.py
+++ b/service/comfyui_downloader.py
@@ -10,73 +10,13 @@ import service_config
 from web_request_bodies import ComfyUICustomNodesGithubRepoId
 
 
-git_download_url = "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip"
-comfyUI_git_repo_url = "https://github.com/comfyanonymous/ComfyUI.git"
-comfyUI_manager_git_repo_url = "https://github.com/ltdrdata/ComfyUI-Manager.git"
-
 def is_comfyUI_installed() -> bool:
     return os.path.exists(service_config.comfy_ui_root_path)
+
 
 def is_git_installed() -> bool:
     return os.path.exists(service_config.git.get("rootDirPath"))
 
-def _install_portable_git():
-    if is_git_installed():
-        logging.info("Omitting installation of git, as already present")
-        return
-    zipped_portable_git_target = f"{service_config.git.get('rootDirPath')}.zip"
-    git_target_dir = service_config.git.get('rootDirPath')
-
-    try:
-        aipg_utils.remove_existing_filesystem_resource(zipped_portable_git_target)
-        aipg_utils.remove_existing_filesystem_resource(git_target_dir)
-
-        _fetch_portable_git(zipped_portable_git_target)
-        _unzip_portable_git(zipped_portable_git_target, git_target_dir)
-        if not is_git_installed():
-            raise AssertionError("Failed to install git at expected location")
-        logging.info(f"successfully extracted git into {os.path.abspath(git_target_dir)}")
-    except Exception as e:
-        logging.error(f"failed to install git due to {e}. Cleaning up intermediate resources")
-        aipg_utils.remove_existing_filesystem_resource(zipped_portable_git_target)
-        aipg_utils.remove_existing_filesystem_resource(git_target_dir)
-        raise e
-
-
-def _fetch_portable_git(seven_zipped_portable_git_target):
-    try:
-        response = requests.get(git_download_url, stream=True, timeout=30)
-        if response.status_code == 200:
-            with open(seven_zipped_portable_git_target, "wb") as file:
-                for chunk in response.iter_content(chunk_size=1024):
-                    file.write(chunk)
-        else:
-            logging.error(f"Failed fetching resources from {git_download_url}")
-            raise Exception(f"fetching {git_download_url} failed with response: {response}")
-    except Exception as e:
-        logging.error(f"Failed to fetch portable git from {git_download_url} with error {e}")
-        aipg_utils.remove_existing_filesystem_resource(seven_zipped_portable_git_target)
-        raise e
-
-
-def _unzip_portable_git(zipped_git_path, target_dir):
-    def get_unzipping_command():
-        try:
-            aipg_utils.call_subprocess("tar --version")
-            logging.debug("using system tar to unzip.")
-            return f"tar -C {target_dir} -xf {zipped_git_path}"
-        except Exception:
-            logging.warning("falling back to powershell command to extract zip, as tar not in PATH")
-            return f"powershell -command 'Expand-Archive' -Force {zipped_git_path} {target_dir}"
-    try:
-        if not os.path.exists(target_dir):
-            os.makedirs(target_dir, exist_ok=True)
-        aipg_utils.call_subprocess(get_unzipping_command())
-        logging.info("Unzipped git successfully")
-    except Exception as e:
-        aipg_utils.remove_existing_filesystem_resource(zipped_git_path)
-        aipg_utils.remove_existing_filesystem_resource(target_dir)
-        raise e
 
 def _install_git_repo(git_repo_url: str, target_dir: str):
     try:
@@ -87,6 +27,7 @@ def _install_git_repo(git_repo_url: str, target_dir: str):
         logging.warning(f"git cloned failed with exception {e}. Cleaning up failed resources.")
         aipg_utils.remove_existing_filesystem_resource(target_dir)
         raise e
+
 
 def _checkout_git_ref(repo_dir: str, git_ref: Optional[str]):
     if git_ref is None or not git_ref.strip():
@@ -147,6 +88,7 @@ def install_pypi_package(packageSpecifier: str):
     aipg_utils.remove_existing_filesystem_resource('./dep.whl')
     logging.info("python package installation completed.")
 
+
 def is_package_installed(packageSpecifier: str):
     installed_packages = aipg_utils.call_subprocess(f"{service_config.comfyui_python_exe} -m pip list")
     if packageSpecifier.endswith(".whl"):
@@ -156,22 +98,6 @@ def is_package_installed(packageSpecifier: str):
     if package_name in installed_packages:
         return True
     return False
-    
-
-def install_comfyUI() -> bool:
-    if is_comfyUI_installed():
-        logging.info("comfyUI installation requested, while already installed")
-        return True
-    try:
-        _install_portable_git()
-        _install_git_repo(comfyUI_git_repo_url, service_config.comfy_ui_root_path)
-        _install_pip_requirements(os.path.join(service_config.comfy_ui_root_path, "requirements.txt"))
-        return True
-    except Exception as e:
-        logging.error(f"comfyUI installation failed due to {e}")
-        if os.path.exists(service_config.comfy_ui_root_path):
-            aipg_utils.remove_existing_filesystem_resource(service_config.comfy_ui_root_path)
-        raise e
 
 
 def is_custom_node_installed_with_git_ref(node_repo_ref: ComfyUICustomNodesGithubRepoId) -> bool:
@@ -201,6 +127,7 @@ def download_custom_node(node_repo_data: ComfyUICustomNodesGithubRepoId) -> bool
             logging.error(f"Failed to install custom comfy node {node_repo_data.username}/{node_repo_data.repoName} due to {e}")
             return False
 
+
 # Gourieff/ComfyUI-ReActor/scripts/reactor_sfw.py
 REACTOR_SFW_PATCH = """from transformers import pipeline
 from PIL import Image
@@ -225,6 +152,7 @@ def nsfw_image(img_path: str, model_path: str):
         # If no 'nsfw' label found, consider it safe
         return False
 """
+
 
 def _patch_custom_node_if_required(custom_node_path: str, node_repo_data: ComfyUICustomNodesGithubRepoId):
     if f"{node_repo_data.username}/{node_repo_data.repoName}@{node_repo_data.gitRef}".lower() == "Gourieff/comfyui-reactor@d2318ad140582c6d0b68c51df342319b502006ed".lower():


### PR DESCRIPTION
**Description:**

This PR changes the git-portable version that is installed from the minimal version to the standard version in order to support git-lfs, which is required by some ComfyUI custom_nodes.
It also adds the git-portable directory to the PATH of the python services so that pip can install packages from git repositories, which is also required by some ComfyUI custom_nodes.

**Related Issue:**

#206 
#211 

**Changes Made:**

* use full portable-git version
* add git to python env PATH

**Testing Done:**

Tested locally on B580 and A750

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
