### PR TITLE
Remove cache logic to avoid issues when AIPG is not running on the same drive as %USERPROFILE%

### DIFF
--- a/service/sd_adapter.py
+++ b/service/sd_adapter.py
@@ -100,7 +100,6 @@ class SD_SSE_Adapter:
         if not os.path.exists(dir):
             os.makedirs(dir)
         image.save(filename)
-        utils.cache_file(filename, os.path.getsize(filename))
 
         response_params = self.get_response_params(
             image, os.path.getsize(filename), params


### PR DESCRIPTION
**Description:**

This PR fixes an issue when AIPG was installed on a different drive then the new output location of images in %USERPROFILE%.

**Changes Made:**

* remove cache logic during image generation with ai-backend

**Testing Done:**

Tested locally on B580

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
