### PR TITLE
Add "BMG only" tag to colorize workflow

### DIFF
--- a/WebUI/external/workflows/Colorize.json
+++ b/WebUI/external/workflows/Colorize.json
@@ -5,7 +5,7 @@
     "customNodes": ["kijai/ComfyUI-DDColor@30d5b8e7666382a6a78404caee28dfa87f741037"],
     "requiredModels": []
   },
-  "tags": [],
+  "tags": ["BMG only"],
   "requirements": ["high-vram"],
   "inputs": [
     {


### PR DESCRIPTION
**Description:**

This PR adds the tag "BMG only" to the Colorize workflow to warn Alchemist users that the workflow is currently not working on Alchemist GPUs.

**Related Issue:**

#211

**Changes Made:**

* add tag

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
