### PR TITLE
fix: do not put a dark overlay on top of fully generated images

### DIFF
--- a/WebUI/src/views/Create.vue
+++ b/WebUI/src/views/Create.vue
@@ -58,7 +58,7 @@
           </div>
           <div
             v-show="imageGeneration.processing"
-            class="absolute left-0 top-0 w-full h-full bg-black/50 flex justify-center items-center"
+            class="absolute left-0 top-0 w-full h-full flex justify-center items-center"
           >
             <loading-bar
               v-if="
@@ -74,10 +74,10 @@
             ></loading-bar>
             <div
               v-else-if="currentImage?.state === 'generating' || currentImage?.state === 'queued'"
-              class="flex gap-2 items-center justify-center text-white"
+              class="flex gap-2 items-center justify-center text-white bg-black/50 py-6 px-12 rounded-lg"
             >
               <span class="svg-icon i-loading w-8 h-8"></span>
-              <span class="text-2xl">{{ imageGeneration.stepText }}</span>
+              <span class="text-2xl tabular-nums" style="min-width: 200px;">{{ imageGeneration.stepText }}</span>
             </div>
           </div>
           <div


### PR DESCRIPTION
**Description:**

This PR prevents a dark overlay, originally added for display while generating images, to be put on top of images that are already done generating.

**Related Issue:**

If this pull request is related to any existing issue, please mention the issue number here.

**Changes Made:**

* limit dark overlay to the background of the "generating ..." text

**Testing Done:**

Tested locally on B580

**Screenshots:**

![image](https://github.com/user-attachments/assets/4c2fc03f-e91e-4570-a5d7-6eeeb3323586)
![image](https://github.com/user-attachments/assets/035612dc-2339-468e-a405-eba7b6696843)


**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
