### PR TITLE
Upgrade OpenVINO to 2025.1

### DIFF
--- a/OpenVINO/requirements.txt
+++ b/OpenVINO/requirements.txt
@@ -1,6 +1,5 @@
---extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
 Flask==3.0.3
 apiflask==2.3.0
-openvino==2025.1.0.dev20250203
-openvino-genai==2025.1.0.0.dev20250203
-openvino-tokenizers==2025.1.0.0.dev20250203
+openvino==2025.1.0.0
+openvino-genai==2025.1.0.0
+openvino-tokenizers==2025.1.0.0

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -55,8 +55,6 @@ export class OpenVINOBackendService extends LongLivedPythonApiService {
       const commonRequirements = existingFileOrError(path.join(this.serviceDir, 'requirements.txt'))
       await this.uvPip.run([
         'install',
-        '--index-strategy',
-        'unsafe-best-match',
         '-r',
         commonRequirements,
       ])

--- a/WebUI/src/assets/js/store/models.ts
+++ b/WebUI/src/assets/js/store/models.ts
@@ -46,6 +46,8 @@ const predefinedModels: Omit<Model, 'downloaded'>[] = [
   },
   { name: 'OpenVINO/Phi-3.5-mini-instruct-int4-ov', type: 'openVINO', default: true },
   { name: 'OpenVINO/Phi-3-mini-4k-instruct-int4-ov', type: 'openVINO', default: false },
+  { name: 'OpenVINO/DeepSeek-R1-Distill-Qwen-1.5B-int4-ov', type: 'openVINO', default: false },
+  { name: 'OpenVINO/DeepSeek-R1-Distill-Qwen-7B-int4-ov', type: 'openVINO', default: false },
   { name: 'OpenVINO/Mistral-7B-Instruct-v0.2-int4-ov', type: 'openVINO', default: false },
   { name: 'OpenVINO/TinyLlama-1.1B-Chat-v1.0-int4-ov', type: 'openVINO', default: false },
 ]

--- a/WebUI/src/assets/js/store/textInference.ts
+++ b/WebUI/src/assets/js/store/textInference.ts
@@ -4,7 +4,8 @@ import { useBackendServices } from './backendServices'
 import { useModels } from './models'
 import * as Const from '@/assets/js/const'
 
-export const llmBackendTypes = ['ipexLLM', 'llamaCPP', 'openVINO'] as const
+export const llmBackendTypes = ['ipexLLM', 'openVINO', 'llamaCPP'] as const
+
 const LlmBackendSchema = z.enum(llmBackendTypes)
 export type LlmBackend = z.infer<typeof LlmBackendSchema>
 

--- a/WebUI/src/views/Answer.vue
+++ b/WebUI/src/views/Answer.vue
@@ -592,6 +592,9 @@ const ragData = reactive({
 const thinkingModels: Record<string, string> = {
   'deepseek-ai/DeepSeek-R1-Distill-Qwen-14B': '</think>\n\n',
   'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B': '</think>\n\n',
+  'OpenVINO/DeepSeek-R1-Distill-Qwen-1.5B-int4-ov': '</think>\n\n',
+  'OpenVINO/DeepSeek-R1-Distill-Qwen-7B-int4-ov': '</think>\n\n',
+  'OpenVINO/DeepSeek-R1-Distill-Qwen-14B-int4-ov': '</think>\n\n',
 }
 
 const markerFound = ref(false)


### PR DESCRIPTION
**Description:**

This PR upgrades the OpenVINO version to 2025.1.0.0 and adds OpenVINO DeepSeek models to the predefined model list.

**Changes Made:**

* bump OV version
* add OV DeepSeek models

**Testing Done:**

Tested locally on B580

**Screenshots:**

<img width="714" alt="image" src="https://github.com/user-attachments/assets/51a464b3-5af5-4037-8f5b-d7d62b66298d" />

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
