### PR TITLE
fix: prevent installation for all users

### DIFF
--- a/WebUI/build/installer.nsh
+++ b/WebUI/build/installer.nsh
@@ -3,6 +3,10 @@
   ShowUninstDetails show
 !macroend
 
+!macro customInstallMode
+    StrCpy $isForceCurrentInstall "1"
+    StrCpy $isForceMachineInstall "0"
+!macroend
 
 !macro customInstall
 


### PR DESCRIPTION
**Description:**

This PR disables the option to install AI Playground for all users, as it is incompatible with the recent change that prevents execution as admin (https://github.com/intel/AI-Playground/pull/237)

**Changes Made:**

* disable install for all users

**Testing Done:**

Tested locally on B580

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
