### PR TITLE
Allow overriding the architecture via settings.json

### DIFF
--- a/WebUI/electron/electron-env.d.ts
+++ b/WebUI/electron/electron-env.d.ts
@@ -36,6 +36,7 @@ type Theme = 'dark' | 'lnl' | 'bmg'
 type LocalSettings = {
   debug: number
   comfyUiParameters?: string[]
+  deviceArchOverride?: 'bmg' | 'acm' | 'arl_h' | 'lnl' | 'mtl'
 } & KVObject
 
 type ThemeSettings = {

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -95,6 +95,7 @@ export const settings: LocalSettings = {
   availableThemes: ['dark', 'lnl'],
   currentTheme: 'lnl',
   comfyUiParameters: [],
+  deviceArchOverride: undefined,
 }
 
 async function loadSettings() {

--- a/WebUI/electron/subprocesses/aiBackendService.ts
+++ b/WebUI/electron/subprocesses/aiBackendService.ts
@@ -41,7 +41,8 @@ export class AiBackendService extends LongLivedPythonApiService {
       await this.uvPip.ensureInstalled()
       await this.deviceService.ensureInstalled()
 
-      const deviceArch = await this.deviceService.getBestDeviceArch()
+      const deviceArch =
+        this.settings.deviceArchOverride ?? (await this.deviceService.getBestDeviceArch())
       yield {
         serviceName: this.name,
         step: `Detecting intel device`,

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -135,7 +135,8 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
         status: 'executing',
         debugMessage: `Trying to identify intel hardware`,
       }
-      const deviceArch = await this.deviceService.getBestDeviceArch()
+      const deviceArch =
+        this.settings.deviceArchOverride ?? (await this.deviceService.getBestDeviceArch())
       yield {
         serviceName: this.name,
         step: `Detecting intel device`,

--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -39,14 +39,6 @@ export class LlamaCppBackendService extends LongLivedPythonApiService {
       await this.lsLevelZero.ensureInstalled()
       await this.uvPip.ensureInstalled()
 
-      const deviceArch = await this.lsLevelZero.getBestDeviceArch()
-      yield {
-        serviceName: this.name,
-        step: `Detecting intel device`,
-        status: 'executing',
-        debugMessage: `detected intel hardware ${deviceArch}`,
-      }
-
       yield {
         serviceName: this.name,
         step: `install dependencies`,

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -38,14 +38,6 @@ export class OpenVINOBackendService extends LongLivedPythonApiService {
       await this.deviceService.ensureInstalled()
       await this.uvPip.ensureInstalled()
 
-      const deviceArch = await this.deviceService.getBestDeviceArch()
-      yield {
-        serviceName: this.name,
-        step: `Detecting intel device`,
-        status: 'executing',
-        debugMessage: `detected intel hardware ${deviceArch}`,
-      }
-
       yield {
         serviceName: this.name,
         step: `install dependencies`,


### PR DESCRIPTION
**Description:**

Under certain circumstances the automatic detection of the correct Intel inference architecture during backend installation doesn't yield the desired result.
This PR allows to override the target architecture by adjusting the settings.json, e.g. via
```settings.json
{
  ...,
  "deviceArchOverride": "bmg"
}
```
Valid values are `'bmg' | 'acm' | 'arl_h' | 'lnl' | 'mtl'`

**Changes Made:**

* allow to override device arch during backend installation via settings.json

**Testing Done:**

Tested locally on B580

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
