### PR TITLE
fix: prevent global pip config from being loaded

### DIFF
--- a/WebUI/electron/subprocesses/aiBackendService.ts
+++ b/WebUI/electron/subprocesses/aiBackendService.ts
@@ -175,6 +175,7 @@ export class AiBackendService extends LongLivedPythonApiService {
       PYTHONIOENCODING: 'utf-8',
       HF_ENDPOINT: this.settings.huggingfaceEndpoint,
       ...levelZeroDeviceSelectorEnv(this.devices.find((d) => d.selected)?.id),
+      PIP_CONFIG_FILE: 'nul',
     }
 
     const apiProcess = spawn(

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -325,6 +325,7 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
       PYTHONIOENCODING: 'utf-8',
       HF_ENDPOINT: this.settings.huggingfaceEndpoint,
       ...levelZeroDeviceSelectorEnv(this.devices.find((d) => d.selected)?.id),
+      PIP_CONFIG_FILE: 'nul',
     }
     const mediaDir = getMediaDir()
     const parameters = [

--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -310,6 +310,7 @@ export class LlamaCppBackendService extends LongLivedPythonApiService {
       LLAMA_LLM_PORT: currentLlmPort.toString(),
       LLAMA_EMBEDDING_PORT: currentEmbeddingPort.toString(),
       ...vulkanDeviceSelectorEnv(this.devices.find((d) => d.selected)?.id),
+      PIP_CONFIG_FILE: 'nul',
     }
 
     this.appLogger.info(

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -187,6 +187,7 @@ export class OpenVINOBackendService extends LongLivedPythonApiService {
       PYTHONIOENCODING: 'utf-8',
       ...(this.currentContextSize ? { MAX_PROMPT_LEN: this.currentContextSize.toString() } : {}),
       ...openVinoDeviceSelectorEnv(this.devices.find((d) => d.selected)?.id),
+      PIP_CONFIG_FILE: 'nul',
     }
 
     const apiProcess = spawn(

--- a/WebUI/electron/subprocesses/service.ts
+++ b/WebUI/electron/subprocesses/service.ts
@@ -63,13 +63,13 @@ export async function createEnhancedErrorDetails(
   service?: PythonService | UvPipService,
 ): Promise<ErrorDetails> {
   const timestamp = new Date().toISOString()
-  
+
   // Capture pip freeze output for installation-related errors
   let pipFreezeOutput: string | undefined
   if (service) {
     pipFreezeOutput = await capturePipFreezeOutput(service)
   }
-  
+
   if (error instanceof ProcessError) {
     return {
       command: `${error.result.command} ${error.result.args.join(' ')}`,
@@ -310,7 +310,13 @@ abstract class ExecutableService extends GenericServiceImpl {
   async run(args: string[] = [], extraEnv?: object, workDir?: string): Promise<string> {
     const exePath = existingFileOrError(this.getExePath())
     try {
-      return await spawnProcessAsync(exePath, args, (data) => this.log(data), extraEnv, workDir)
+      return await spawnProcessAsync(
+        exePath,
+        args,
+        (data) => this.log(data),
+        { ...extraEnv, PIP_CONFIG_FILE: 'nul' },
+        workDir,
+      )
     } catch (error) {
       if (error instanceof ProcessError) {
         // Log detailed error information

--- a/service/aipg_utils.py
+++ b/service/aipg_utils.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import os
 import logging
 import math
 import subprocess
@@ -76,7 +77,7 @@ def call_subprocess(process_command: str, cwd: Optional[str] = None) -> str:
     args = shlex.split(process_command)
     try:
         logging.info(f"calling cmd process: {args}")
-        output = subprocess.check_output(args, cwd=cwd)
+        output = subprocess.check_output(args, cwd=cwd, env={**os.environ, "PIP_CONFIG_FILE": os.devnull})
         return output.decode("utf-8").strip()
     except subprocess.CalledProcessError as e:
         logging.error(f"Failed to call subprocess {process_command} with error {e}")


### PR DESCRIPTION
**Description:**

This PR prevents pip to use global config files during package installations.

**Changes Made:**

* set env variable to disable global config file loading

**Testing Done:**

Tested locally on B580.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
