### PR TITLE
Remember selected device after AI Playground restart

### DIFF
--- a/OpenVINO/openvino_backend.py
+++ b/OpenVINO/openvino_backend.py
@@ -24,15 +24,15 @@ class OpenVino(LLMInterface):
             model_name = model_repo_id.replace("/", "---")
             model_path = path.abspath(path.join(model_base_path, model_name))
 
-            enable_compile_cache = dict()
+            options = dict()
             device = environ.get("OPENVINO_DEVICE", "AUTO")
             if device == "NPU":
-                enable_compile_cache["MAX_PROMPT_LEN"] = int(environ.get("MAX_PROMPT_LEN", 1024))
-                cache_postfix = f"NPU_{str(enable_compile_cache["MAX_PROMPT_LEN"])}"
+                options["MAX_PROMPT_LEN"] = int(environ.get("MAX_PROMPT_LEN", 1024))
+                cache_postfix = f"NPU_{str(options["MAX_PROMPT_LEN"])}"
             else:
-                cache_postfix = device
-            enable_compile_cache["CACHE_DIR"] = f"llm_cache_{cache_postfix}"
-            self._model = openvino_genai.LLMPipeline(model_path, device, **enable_compile_cache)
+                cache_postfix = device.replace(".", "_")
+            options["CACHE_DIR"] = f"llm_cache_{cache_postfix}"
+            self._model = openvino_genai.LLMPipeline(model_path, device, **options)
             self._tokenizer = self._model.get_tokenizer()
 
             self._last_repo_id = model_repo_id

--- a/WebUI/electron/subprocesses/aiBackendService.ts
+++ b/WebUI/electron/subprocesses/aiBackendService.ts
@@ -49,6 +49,7 @@ export class AiBackendService extends LongLivedPythonApiService {
       bestDeviceId = availableDevices[0].name
     }
     this.devices = availableDevices.map((d) => ({ ...d, selected: d.id === bestDeviceId }))
+    this.updateStatus()
   }
 
   getServiceForPipFreeze(): UvPipService {

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -84,6 +84,7 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
     const availableDevices = await detectLevelZeroDevices(this.uvPip.python)
     this.appLogger.info(`detected devices: ${JSON.stringify(availableDevices, null, 2)}`, this.name)
     this.devices = availableDevices.map((d) => ({ ...d, selected: d.id == '0' }))
+    this.updateStatus()
   }
 
   getServiceForPipFreeze(): UvPipService {

--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -149,6 +149,7 @@ export class LlamaCppBackendService extends LongLivedPythonApiService {
       // Fallback to default device on error
       this.devices = [{ id: '0', name: 'Auto select device', selected: true }]
     }
+    this.updateStatus()
   }
 
   getServiceForPipFreeze(): UvPipService {

--- a/WebUI/electron/subprocesses/ollamaBackendService.ts
+++ b/WebUI/electron/subprocesses/ollamaBackendService.ts
@@ -102,6 +102,7 @@ export class OllamaBackendService implements ApiService {
       bestDeviceId = availableDevices[0].name
     }
     this.devices = availableDevices.map((d) => ({ ...d, selected: d.id === bestDeviceId }))
+    this.updateStatus()
   }
 
   async selectDevice(deviceId: string): Promise<void> {

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -35,6 +35,7 @@ export class OpenVINOBackendService extends LongLivedPythonApiService {
       { id: 'AUTO', name: 'Auto select device', selected: true },
       ...availableDevices.map((d) => ({ ...d, selected: d.id == '0' })),
     ]
+    this.updateStatus()
   }
 
   getServiceForPipFreeze(): UvPipService {

--- a/WebUI/package-lock.json
+++ b/WebUI/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-playground",
-  "version": "2.6.1-beta",
+  "version": "2.6.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-playground",
-      "version": "2.6.1-beta",
+      "version": "2.6.2-beta",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.19",
         "@ai-sdk/vue": "^2.0.54",

--- a/WebUI/src/assets/js/store/globalSetup.ts
+++ b/WebUI/src/assets/js/store/globalSetup.ts
@@ -63,8 +63,6 @@ export const useGlobalSetup = defineStore('globalSetup', () => {
     SDHDInpaint: useI18N().state.ENHANCE_INPAINT_USE_IMAGE_MODEL,
   })
 
-  const graphicsList = ref(new Array<GraphicsItem>())
-
   const loadingState = ref<GlobalSetupState>('verifyBackend')
   const errorMessage = ref('')
   const hdPersistentConfirmation = ref(localStorage.getItem('HdPersistentConfirmation') === 'true')
@@ -99,15 +97,6 @@ export const useGlobalSetup = defineStore('globalSetup', () => {
         await util.delay(delay)
       }
     }
-    await reloadGraphics()
-    if (graphicsList.value.length == 0) {
-      await window.electronAPI.showMessageBoxSync({
-        message: useI18N().state.ERROR_UNFOUND_GRAPHICS,
-        title: 'error',
-        icon: 'error',
-      })
-      window.electronAPI.exitApp()
-    }
     loadUserSettings()
   }
 
@@ -125,14 +114,6 @@ export const useGlobalSetup = defineStore('globalSetup', () => {
       )
     }
     return (await response.json()) as string[]
-  }
-
-  async function reloadGraphics() {
-    const response = await fetch(`${defaultBackendBaseUrl.value}/api/getGraphics`, {
-      method: 'POST',
-    })
-    const graphics = (await response.json()) as GraphicsItem[]
-    graphicsList.value.splice(0, graphicsList.value.length, ...graphics)
   }
 
   async function refreshLLMModles() {
@@ -232,9 +213,6 @@ export const useGlobalSetup = defineStore('globalSetup', () => {
       modelSettings.lora = models.value.lora[0]
       changeUserSetup = true
     }
-    if (!graphicsList.value.find((item) => item.index == modelSettings.graphics)) {
-      modelSettings.graphics = graphicsList.value[0].index
-    }
     if (changeUserSetup) {
       localStorage.setItem('ModelSettings', JSON.stringify(toRaw(modelSettings)))
     }
@@ -267,7 +245,6 @@ export const useGlobalSetup = defineStore('globalSetup', () => {
     models,
     paths,
     apiHost: defaultBackendBaseUrl,
-    graphicsList,
     loadingState,
     errorMessage,
     hdPersistentConfirmation,

--- a/WebUI/src/assets/js/store/imageGeneration.ts
+++ b/WebUI/src/assets/js/store/imageGeneration.ts
@@ -536,7 +536,7 @@ export const useImageGeneration = defineStore(
     const getGenerationParameters = (): GenerationSettings => {
       const allSettings = {
         workflow: activeWorkflowName.value ?? 'unknown',
-        device: globalSetup.modelSettings.graphics,
+        device: 0, // TODO get correct device from backend service
         prompt: prompt.value,
         negativePrompt: negativePrompt.value,
         imageModel: imageModel.value,

--- a/WebUI/src/components/SettingsBasic.vue
+++ b/WebUI/src/components/SettingsBasic.vue
@@ -17,25 +17,6 @@
       </div>
     </div>
   </div>
-  <div class="border-b border-color-spilter flex flex-col gap-5 py-4">
-    <p>{{ languages.SETTINGS_INFERENCE_DEVICE }}</p>
-    <div class="flex items-center gap-2 flex-wrap">
-      <drop-selector :array="globalSetup.graphicsList" @change="changeGraphics">
-        <template #selected>
-          <div class="flex gap-2 items-center">
-            <span class="rounded-full bg-green-500 w-2 h-2"></span>
-            <span>{{ graphicsName }}</span>
-          </div>
-        </template>
-        <template #list="slotItem">
-          <div class="flex gap-2 items-center">
-            <span class="rounded-full bg-green-500 w-2 h-2"></span>
-            <span>{{ slotItem.item.name }}</span>
-          </div>
-        </template>
-      </drop-selector>
-    </div>
-  </div>
   <div class="flex flex-col gap-3">
     <p>{{ languages.SETTINGS_BACKEND_STATUS }}</p>
     <table class="text-center w-full mx-2 table-fixed">
@@ -59,7 +40,6 @@
   </div>
 </template>
 <script setup lang="ts">
-import DropSelector from '../components/DropSelector.vue'
 import RadioBlock from '../components/RadioBlock.vue'
 
 import { useGlobalSetup } from '@/assets/js/store/globalSetup'
@@ -93,20 +73,7 @@ const displayComponents = computed(() => {
   }))
 })
 
-const modelSettings = reactive<KVObject>(Object.assign({}, toRaw(globalSetup.modelSettings)))
-
-const graphicsName = computed(() => {
-  return (
-    globalSetup.graphicsList.find((item) => (modelSettings.graphics as number) == item.index)
-      ?.name || ''
-  )
-})
-
 function openDebug() {
   window.electronAPI.openDevTools()
-}
-
-function changeGraphics(value: GraphicsItem, _index: number) {
-  globalSetup.applyModelSettings({ graphics: value.index })
 }
 </script>

--- a/WebUI/src/views/Answer.vue
+++ b/WebUI/src/views/Answer.vue
@@ -755,7 +755,6 @@ async function updateTitle(conversation: ChatItem[]) {
   console.log('prompt', prompt)
   const chatContext = [{ question: prompt, answer: '' }]
   const requestParams = {
-    device: globalSetup.modelSettings.graphics,
     prompt: chatContext,
     max_tokens: 8,
     model_repo_id: textInference.activeModel,
@@ -1022,7 +1021,6 @@ async function generate(chatContext: ChatItem[]) {
     }
 
     const requestParams = {
-      device: globalSetup.modelSettings.graphics,
       prompt: chatContext,
       external_rag_context: externalRagContext,
       max_tokens: textInference.maxTokens,

--- a/WebUI/src/views/Enhance.vue
+++ b/WebUI/src/views/Enhance.vue
@@ -627,7 +627,7 @@ async function generate() {
     lastPostParams = Object.assign(
       {
         mode: mode.value,
-        device: globalSetup.modelSettings.graphics,
+        device: 0,
         prompt: prompt.value,
         model_repo_id: model_repo_id,
         negative_prompt: imageGeneration.negativePrompt,

--- a/backend-shared/interface.py
+++ b/backend-shared/interface.py
@@ -20,7 +20,7 @@ class LLMInterface(ABC):
         Load the model with the given parameters.
         
         Args:
-            params: LLM parameters including model_repo_id, device, etc.
+            params: LLM parameters including model_repo_id, etc.
             **kwargs: Additional backend-specific parameters
         """
         pass

--- a/backend-shared/params.py
+++ b/backend-shared/params.py
@@ -10,7 +10,6 @@ class LLMParams:
     - OpenVINO
     """
     prompt: List[Dict[str, str]]
-    device: int
     model_repo_id: str
     max_tokens: int
     external_rag_context: Optional[str]
@@ -18,7 +17,7 @@ class LLMParams:
     generation_parameters: Dict[str, Any]
 
     def __init__(
-        self, prompt: list, device: int, model_repo_id: str, 
+        self, prompt: list, model_repo_id: str, 
         max_tokens: int, external_rag_context: Optional[str] = None, 
         print_metrics: bool = True, 
         **kwargs
@@ -28,7 +27,6 @@ class LLMParams:
         
         Args:
             prompt: List of prompt dictionaries with "question" and optionally "answer" keys
-            device: Device ID to run inference on
             model_repo_id: Model repository ID or path
             max_tokens: Maximum number of tokens to generate
             external_rag_context: Optional context from external RAG system
@@ -36,7 +34,6 @@ class LLMParams:
             **kwargs: Additional generation parameters passed to the model
         """
         self.prompt = prompt
-        self.device = device
         self.model_repo_id = model_repo_id
         self.max_tokens = max_tokens
         self.external_rag_context = external_rag_context

--- a/service/paint_biz.py
+++ b/service/paint_biz.py
@@ -40,7 +40,6 @@ ipex_init()
 
 
 class TextImageParams:
-    device: int
     prompt: str
     model_name: str
     mode: int
@@ -813,7 +812,7 @@ def generate(params: TextImageParams):
 
     try:
         stop_generate()
-        torch.xpu.set_device(params.device)
+        # torch.xpu.set_device(params.device)
         # service_config.device = f"xpu:{params.device}"
         if _last_model_name != params.model_name:
             # hange model dispose basic model

--- a/service/web_api.py
+++ b/service/web_api.py
@@ -82,7 +82,6 @@ try:
     def sd_generate():
         """
         {
-            "device": int,
             "prompt": str,
             "model_repo_id": str,
             "mode": int,
@@ -109,7 +108,6 @@ try:
         else:
             params = TextImageParams()
         base_params = params
-        base_params.device = request.form.get("device", default=0, type=int)
         base_params.prompt = request.form.get("prompt", default="", type=str)
         base_params.model_name = request.form["model_repo_id"]
         base_params.mode = mode


### PR DESCRIPTION
**Description:**

This PR improves UX by remembering the last used device for each backend after restarting AI Playgronud

**Changes Made:**

* use last used device per backend if still available when AI Playground is restarted.

**Testing Done:**

Tested locally on B580.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
