### PR TITLE
fix: add python env dll folder to PATH during device detection

### DIFF
--- a/WebUI/electron/subprocesses/deviceDetection.ts
+++ b/WebUI/electron/subprocesses/deviceDetection.ts
@@ -1,4 +1,5 @@
 import { PythonService } from './service'
+import path from 'node:path'
 
 type Device = Omit<InferenceDevice, 'selected'>
 
@@ -29,6 +30,7 @@ except Exception as e:
     while ((lastDeviceList.length > 0 || i == 0) && i < 10) {
       // Execute the Python script
       const result = await pythonService.run(['-c', pythonScript], {
+        PATH: `${path.join(pythonService.dir, 'Library', 'bin')};${process.env.PATH}`,
         PYTHONNOUSERSITE: 'true',
         ONEAPI_DEVICE_SELECTOR: `level_zero:${i}`,
       })
@@ -95,7 +97,10 @@ except Exception as e:
 `
 
     // Execute the Python script
-    const result = await pythonService.run(['-c', pythonScript], { PYTHONNOUSERSITE: 'true' })
+    const result = await pythonService.run(['-c', pythonScript], {
+      PATH: `${path.join(pythonService.dir, 'Library', 'bin')};${process.env.PATH}`,
+      PYTHONNOUSERSITE: 'true'
+    })
 
     // Parse the output
     const devices: Device[] = []


### PR DESCRIPTION
**Description:**

Fix an issue, where the `bin` folder, containing required DLLs was not correctly added to the `PATH` environment variable during device detection.

**Changes Made:**

* correctly set `PATH` during device detection.

**Testing Done:**

Tested locally on B580.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.