### PR TITLE
fix z-image vae link, add --no-mmap and turn off flash attention temporary 

### DIFF
--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -549,6 +549,9 @@ export class LlamaCppBackendService implements ApiService {
         ctxSize.toString(),
         '--log-prefix',
         '--jinja',
+        '--no-mmap',
+        '-fa',
+        'off'
       ]
 
       const modelFolder = path.dirname(modelPath)

--- a/WebUI/external/presets/z-image.json
+++ b/WebUI/external/presets/z-image.json
@@ -176,7 +176,7 @@
     },
     "40": {
       "inputs": {
-        "vae_name": "Comfy-Org---Lumina_Image_2.0_Repackaged\\split_files\\vae\\ae.safetensors"
+        "vae_name": "Comfy-Org---z_image_turbo\\split_files\\vae\\ae.safetensors"
       },
       "class_type": "VAELoader",
       "_meta": {


### PR DESCRIPTION

1. Fix z-image vae link to use the downloaded z-image-turbo vae

2. add --no-mmap to llama-server launch arg to avoid extra memory consumption

3. Turn off flash attention by adding -fa off to llama-server temporary 