### PR TITLE
Fix Linux multiarch dependency detection and OVMS libxml2 crash

### DIFF
--- a/WebUI/electron/subprocesses/linuxPackageInstaller.ts
+++ b/WebUI/electron/subprocesses/linuxPackageInstaller.ts
@@ -29,7 +29,13 @@ export async function hasPkexec(): Promise<boolean> {
 export async function isAptPackageInstalled(packageName: string): Promise<boolean> {
   try {
     const { stdout } = await execAsync("dpkg-query -W -f='${db:Status-Status}' " + packageName)
-    return stdout.trim() === 'installed'
+    // On multiarch systems (e.g. i386 packages pulled in by Wine/Steam) an
+    // unqualified package name matches one record per installed architecture,
+    // so dpkg-query concatenates the status field with no separator (e.g.
+    // "installedinstalled"). Accept any repetition of "installed", but still
+    // reject unrelated statuses that contain it as a substring (e.g.
+    // "not-installed").
+    return /^(installed)+$/.test(stdout.trim())
   } catch {
     return false
   }

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -29,6 +29,39 @@ import { resolveDefaultDevice } from './defaultDeviceSelection.ts'
 
 const execAsync = promisify(exec)
 
+/**
+ * Parse `ldconfig -p` output into a map of soname -> real library path.
+ *
+ * On multiarch systems (e.g. i386 packages pulled in by Wine/Steam) ldconfig -p
+ * lists one entry per installed architecture under the SAME soname, e.g.:
+ *   libxml2.so.16 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libxml2.so.16
+ *   libxml2.so.16 (libc6)        => /usr/lib/i386-linux-gnu/libxml2.so.16
+ * AI Playground's Linux build is x86-64 only, so an i386 (or other foreign-arch)
+ * entry must never win over an x86-64 one, regardless of line order: loading a
+ * 32-bit library into the 64-bit OVMS process fails with "wrong ELF class:
+ * ELFCLASS32". A foreign-arch tag never contains "x86-64"/"x86_64" (i386 is
+ * tagged just "(libc6)" on an amd64 host), so once an x86-64 entry is seen for a
+ * soname it is kept even if a later foreign-arch line repeats that soname.
+ */
+export function parseLdconfigOutput(ldconfigOutput: string): Map<string, string> {
+  const ldconfigMap = new Map<string, string>()
+  const x86_64Sonames = new Set<string>()
+  for (const line of ldconfigOutput.split('\n')) {
+    // Line format: "	libfoo.so.2 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libfoo.so.2"
+    const m = line.match(/^\s*(\S+)\s+\(([^)]*)\)\s+=>\s+(\S+)/)
+    if (!m?.[1] || !m?.[3]) continue
+    const [, soname, tag, libPath] = m
+    const isX86_64 = /x86[-_]64/.test(tag ?? '')
+    if (isX86_64) {
+      ldconfigMap.set(soname, libPath)
+      x86_64Sonames.add(soname)
+    } else if (!x86_64Sonames.has(soname)) {
+      ldconfigMap.set(soname, libPath)
+    }
+  }
+  return ldconfigMap
+}
+
 interface OvmsServerProcess {
   process: ChildProcess
   port: number
@@ -503,12 +536,7 @@ export class OpenVINOBackendService implements ApiService {
       return
     }
 
-    const ldconfigMap = new Map<string, string>()
-    for (const line of ldconfigOutput.split('\n')) {
-      // Line format: "	libfoo.so.2 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libfoo.so.2"
-      const m = line.match(/^\s*(\S+)\s+\([^)]+\)\s+=>\s+(\S+)/)
-      if (m?.[1] && m?.[2]) ldconfigMap.set(m[1], m[2])
-    }
+    const ldconfigMap = parseLdconfigOutput(ldconfigOutput)
 
     for (const missingLib of missingLibs) {
       const symlinkPath = path.join(ovmsLibDir, missingLib)

--- a/WebUI/electron/test/subprocesses/linuxPackageInstaller.test.ts
+++ b/WebUI/electron/test/subprocesses/linuxPackageInstaller.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const execMock = vi.fn()
+
+vi.mock('child_process', () => ({
+  exec: (...args: unknown[]) => execMock(...args),
+}))
+
+// isAptPackageInstalled is imported after the mock so promisify(exec) picks it up.
+const { isAptPackageInstalled } = await import('../../subprocesses/linuxPackageInstaller')
+
+function mockDpkgQueryOutput(stdout: string) {
+  execMock.mockImplementation((_cmd: string, cb: (err: unknown, result: unknown) => void) => {
+    cb(null, { stdout, stderr: '' })
+  })
+}
+
+function mockDpkgQueryError() {
+  execMock.mockImplementation((_cmd: string, cb: (err: unknown, result: unknown) => void) => {
+    cb(new Error('no packages found matching pkg'), null)
+  })
+}
+
+describe('isAptPackageInstalled', () => {
+  beforeEach(() => {
+    execMock.mockReset()
+  })
+
+  it('returns true for a normal single-architecture match', async () => {
+    mockDpkgQueryOutput('installed')
+    await expect(isAptPackageInstalled('libgomp1')).resolves.toBe(true)
+  })
+
+  it('returns true when dpkg-query concatenates statuses for a multiarch package', async () => {
+    // Reproduces the real output on a system with both amd64 and i386 installed
+    // (e.g. i386 pulled in by Wine/Steam), which previously broke the exact
+    // string-equality check.
+    mockDpkgQueryOutput('installedinstalled')
+    await expect(isAptPackageInstalled('libgomp1')).resolves.toBe(true)
+  })
+
+  it('returns false when the package is not installed', async () => {
+    mockDpkgQueryOutput('not-installed')
+    await expect(isAptPackageInstalled('libgomp1')).resolves.toBe(false)
+  })
+
+  it('returns false when dpkg-query errors (package unknown)', async () => {
+    mockDpkgQueryError()
+    await expect(isAptPackageInstalled('does-not-exist')).resolves.toBe(false)
+  })
+})

--- a/WebUI/electron/test/subprocesses/openVINOBackendService.test.ts
+++ b/WebUI/electron/test/subprocesses/openVINOBackendService.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('electron', () => ({ app: { isPackaged: false } }))
+
+import { parseLdconfigOutput } from '../../subprocesses/openVINOBackendService'
+
+describe('parseLdconfigOutput', () => {
+  it('resolves a single-architecture soname to its path', () => {
+    const output = '\tlibxml2.so.16 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libxml2.so.16\n'
+    const map = parseLdconfigOutput(output)
+    expect(map.get('libxml2.so.16')).toBe('/usr/lib/x86_64-linux-gnu/libxml2.so.16')
+  })
+
+  it('prefers the x86-64 entry over a foreign-arch entry listed after it', () => {
+    // Reproduces real `ldconfig -p` output on a multiarch system (e.g. i386
+    // pulled in by Wine/Steam) with both amd64 and i386 libxml2 installed.
+    // The i386 line has no "x86-64" tag and appears after the x86-64 line.
+    const output = [
+      '\tlibxml2.so.16 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libxml2.so.16',
+      '\tlibxml2.so.16 (libc6) => /usr/lib/i386-linux-gnu/libxml2.so.16',
+      '',
+    ].join('\n')
+    const map = parseLdconfigOutput(output)
+    expect(map.get('libxml2.so.16')).toBe('/usr/lib/x86_64-linux-gnu/libxml2.so.16')
+  })
+
+  it('prefers the x86-64 entry even when the foreign-arch entry is listed first', () => {
+    const output = [
+      '\tlibxml2.so.16 (libc6) => /usr/lib/i386-linux-gnu/libxml2.so.16',
+      '\tlibxml2.so.16 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libxml2.so.16',
+      '',
+    ].join('\n')
+    const map = parseLdconfigOutput(output)
+    expect(map.get('libxml2.so.16')).toBe('/usr/lib/x86_64-linux-gnu/libxml2.so.16')
+  })
+
+  it('falls back to the only available entry when no x86-64 tag exists at all', () => {
+    const output = '\tlibfoo.so.1 (libc6) => /usr/lib/i386-linux-gnu/libfoo.so.1\n'
+    const map = parseLdconfigOutput(output)
+    expect(map.get('libfoo.so.1')).toBe('/usr/lib/i386-linux-gnu/libfoo.so.1')
+  })
+
+  it('ignores unparsable lines', () => {
+    const output = ['1234 libs found in cache `/etc/ld.so.cache\'', '\tnot a valid line', ''].join(
+      '\n',
+    )
+    const map = parseLdconfigOutput(output)
+    expect(map.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Two related bugs affecting Linux systems with a foreign architecture enabled (e.g. i386 packages pulled in by Wine or Steam), both caused by code that reads multiarch `dpkg`/`ldconfig` output without being architecture-aware.

### 1. `isAptPackageInstalled()` wrongly reports installed packages as missing

`WebUI/electron/subprocesses/linuxPackageInstaller.ts` runs `dpkg-query -W -f='${db:Status-Status}' <pkg>` without an architecture qualifier and compares the output to the exact string `installed`. On a multiarch system, `dpkg-query` matches one record per installed architecture and concatenates the status field with **no separator**, e.g. `installedinstalled` for a package installed for both `amd64` and `i386`. That breaks the exact-match check even though the package genuinely is installed, so OpenVINO (and ComfyUI) Linux setup wrongly reports required packages as still missing after the installer step runs, and setup fails with `Dependencies still missing after installer: libgomp1, libnuma1, ocl-icd-libopencl1`.

Reproduced on a stock Ubuntu install with `libwine:i386`/`libx265-215:i386`/`libsoxr0:i386` present, which pull in `i386` copies of `libgomp1`, `libnuma1`, and `ocl-icd-libopencl1` alongside the `amd64` ones already required by OpenVINO.

**Fix:** accept any repetition of `installed` (covers 1+ architectures reporting the same status) while still rejecting unrelated statuses that contain the substring, like `not-installed`:

```ts
return /^(installed)+$/.test(stdout.trim())
```

### 2. OVMS crashes with `wrong ELF class: ELFCLASS32` loading `libxml2`

`ensureOvmsMissingLibSymlinks()` resolves a missing OVMS shared library (e.g. `libxml2.so.2`) to a compatible system library via a `soname -> path` map built from `ldconfig -p`. On the same kind of multiarch system, `ldconfig -p` lists one entry per architecture under the identical soname key with no architecture-aware precedence:

```
libxml2.so.16 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libxml2.so.16
libxml2.so.16 (libc6)        => /usr/lib/i386-linux-gnu/libxml2.so.16
```

The map ends up keyed to whichever line happens to come last. When that's the i386 line, the compat symlink points OVMS (a 64-bit process) at a 32-bit library, and OVMS crashes on startup with `error while loading shared libraries: libxml2.so.2: wrong ELF class: ELFCLASS32`. This surfaces in the UI as "Failed to start transcription server" when enabling Speech to Text, and would affect any other OVMS feature needing the same kind of fallback library.

**Fix:** extract the `ldconfig -p` parsing into `parseLdconfigOutput()` and make it architecture-aware: an `x86-64`-tagged entry always wins over a foreign-arch entry for the same soname, regardless of line order. AI Playground's Linux build targets x86-64 only, so this is safe and matches the existing hardcoded `x86_64-linux-gnu` paths used elsewhere in this file's Linux support code.

## Test plan

- [x] Added `linuxPackageInstaller.test.ts` covering single-arch and multiarch `dpkg-query` output.
- [x] Added `openVINOBackendService.test.ts` covering `parseLdconfigOutput()` with real multiarch `ldconfig -p` output reproduced from an affected system (x86-64 entry first, foreign-arch entry first, foreign-arch-only fallback, unparsable lines).
- [x] Reproduced the `libxml2.so.2` `ELFCLASS32` crash on a live installation (Ubuntu with i386 foreign architecture enabled) and confirmed the fix resolves it: `ldd` on the OVMS binary now resolves `libxml2.so.2` to the x86-64 library instead of the i386 one.
- [x] Full electron test suite (`npx vitest run electron/test/subprocesses/`), `tsc --noEmit`, and `eslint` pass with no regressions.
- [x] Manually verified against a real multiarch Ubuntu install where OpenVINO setup previously failed; after patching, dependency detection and the OVMS compat-symlink logic both behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
